### PR TITLE
feat: persist words via server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # Flash-card-site
 
-A simple German–English flashcard game built for GitHub Pages.
+A simple German–English flashcard game.
 
 ## Features
 
 - Shows a German word and lets you reveal the English translation.
 - Switch modes to see the English word first.
-- Manage your own list of words. Added pairs are saved in your browser and used in the game.
+- Manage a shared list of words stored on the server.
 
 ## Usage
 
-Open `index.html` in a browser or host the repository with GitHub Pages.
+```
+npm install
+npm start
+```
 
-No build step or dependencies are required.
+Then open `http://localhost:3000` in a browser.
+
+Words are persisted in `words.json` on the server.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "flash-card-site",
+  "version": "1.0.0",
+  "description": "German flashcard app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,11 +1,4 @@
-const defaultWords = [
-  { de: 'Hallo', en: 'Hello' },
-  { de: 'Tschüss', en: 'Goodbye' },
-  { de: 'Hund', en: 'Dog' },
-  { de: 'Katze', en: 'Cat' }
-];
-
-let words = JSON.parse(localStorage.getItem('flashcards-words')) || defaultWords;
+let words = [];
 let currentMode = 'deToEn';
 let currentIndex = -1;
 
@@ -20,8 +13,10 @@ const addWordForm = document.getElementById('add-word-form');
 const newGermanInput = document.getElementById('new-german');
 const newEnglishInput = document.getElementById('new-english');
 
-function saveWords() {
-  localStorage.setItem('flashcards-words', JSON.stringify(words));
+async function fetchWords() {
+  const res = await fetch('/api/words');
+  words = await res.json();
+  renderWordList();
 }
 
 function renderWordList() {
@@ -64,19 +59,26 @@ toggleModeBtn.addEventListener('click', () => {
 });
 manageWordsBtn.addEventListener('click', () => {
   wordManagerSection.classList.toggle('hidden');
-  renderWordList();
+  if (!wordManagerSection.classList.contains('hidden')) {
+    fetchWords();
+  }
 });
-addWordForm.addEventListener('submit', e => {
+
+addWordForm.addEventListener('submit', async e => {
   e.preventDefault();
   const de = newGermanInput.value.trim();
   const en = newEnglishInput.value.trim();
   if (de && en) {
-    words.push({ de, en });
-    saveWords();
-    renderWordList();
+    await fetch('/api/words', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ de, en })
+    });
     newGermanInput.value = '';
     newEnglishInput.value = '';
+    await fetchWords();
+    showNextWord();
   }
 });
 
-showNextWord();
+fetchWords().then(showNextWord);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const wordsFile = path.join(__dirname, 'words.json');
+
+app.use(express.static(__dirname));
+app.use(express.json());
+
+function readWords() {
+  try {
+    return JSON.parse(fs.readFileSync(wordsFile, 'utf8'));
+  } catch (err) {
+    return [];
+  }
+}
+
+function writeWords(words) {
+  fs.writeFileSync(wordsFile, JSON.stringify(words, null, 2));
+}
+
+app.get('/api/words', (req, res) => {
+  res.json(readWords());
+});
+
+app.post('/api/words', (req, res) => {
+  const { de, en } = req.body;
+  if (!de || !en) {
+    return res.status(400).json({ error: 'Both de and en fields are required.' });
+  }
+  const words = readWords();
+  words.push({ de, en });
+  writeWords(words);
+  res.status(201).json({ message: 'Word added.' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/words.json
+++ b/words.json
@@ -1,0 +1,6 @@
+[
+  { "de": "Hallo", "en": "Hello" },
+  { "de": "Tschüss", "en": "Goodbye" },
+  { "de": "Hund", "en": "Dog" },
+  { "de": "Katze", "en": "Cat" }
+]


### PR DESCRIPTION
## Summary
- serve static flashcard app with Express and save words to a JSON file for shared persistence
- update client script to load and add words through the new API
- refresh README with steps for running the server

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test`
- `node server.js` (fails: Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_e_688e1352c3a083288fef89742e8b4d25