### PR TITLE
Fix word list caching issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,8 +14,14 @@ const newGermanInput = document.getElementById('new-german');
 const newEnglishInput = document.getElementById('new-english');
 
 async function fetchWords() {
-  const res = await fetch('/api/words');
-  words = await res.json();
+  try {
+    const res = await fetch('/api/words', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to load words');
+    words = await res.json();
+  } catch (err) {
+    console.error(err);
+    words = [];
+  }
   renderWordList();
 }
 

--- a/server.js
+++ b/server.js
@@ -6,6 +6,9 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const wordsFile = path.join(__dirname, 'words.json');
 
+// Disable caching so clients always receive fresh data
+app.disable('etag');
+
 app.use(express.static(__dirname));
 app.use(express.json());
 
@@ -22,6 +25,7 @@ function writeWords(words) {
 }
 
 app.get('/api/words', (req, res) => {
+  res.set('Cache-Control', 'no-store');
   res.json(readWords());
 });
 


### PR DESCRIPTION
## Summary
- ensure API responses are not cached and always deliver fresh word data
- handle fetch failures on the client and bypass browser cache

## Testing
- `npm test`
- `curl -i http://localhost:3000/api/words`


------
https://chatgpt.com/codex/tasks/task_e_688f8dbfe1dc8328a710cc411b8eeb99